### PR TITLE
Update copyright year to 2025 in French locale

### DIFF
--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -28,7 +28,7 @@
     "nav_booking": "Prendre rendez-vous",
     "contact_title": "Contact & Réseaux",
     "google_business": "Fiche Google",
-    "copyright": "© {year} Isaac Miller. Tous droits réservés.",
+    "copyright": "© 2025 Isaac Miller. Tous droits réservés.",
     "legal_notice": "Mentions légales",
     "privacy_policy": "Politique de confidentialité"
   }


### PR DESCRIPTION
Updates the copyright year from a dynamic {year} placeholder to the static value "2025" in the French translation file.

Changes:
- Modified copyright string in src/locales/fr/common.json
- Changed from "© {year} Isaac Miller. Tous droits réservés." to "© 2025 Isaac Miller. Tous droits réservés."
- Added missing newline at end of file

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a7df9cf20f1b414ba2edd74d9be9dc09/nova-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a7df9cf20f1b414ba2edd74d9be9dc09</projectId>-->
<!--<branchName>nova-field</branchName>-->